### PR TITLE
add support for csv and json audit reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,7 @@ await playAudit({
 
 ## Generating audit reports
 
-`playwright-lighthouse` library can produce very famous Lighthouse HTML audit report, that you can host in your CI server. This report is really necessary to check the detailed report.
-
-In addition to the HTML audit report, `playwright-lighthouse` can also produce CSV and JSON audit reports. These can be useful for ongoing audits and monitoring from build to build.
+`playwright-lighthouse` library can produce  Lighthouse CSV, HTML and JSON audit reports, that you can host in your CI server. These reports can be useful for ongoing audits and monitoring from build to build.
 
 ```js
 await playAudit({
@@ -142,9 +140,8 @@ await playAudit({
     html: true, //defaults to false
     csv: true //defaults to false
   },
-  htmlReport: true, //defaults to false
-  reportDir: `path/to/directory`, //defaults to `${process.cwd()}/lighthouse`
-  reportName: `name-of-the-report`, //defaults to `lighthouse-${new Date().getTime()}.html`
+  name: `name-of-the-report`, //defaults to `lighthouse-${new Date().getTime()}`
+  directory:  `path/to/directory`, //defaults to `${process.cwd()}/lighthouse`
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,21 +127,28 @@ await playAudit({
 });
 ```
 
-## Generating HTML audit report
+## Generating audit reports
 
 `playwright-lighthouse` library can produce very famous Lighthouse HTML audit report, that you can host in your CI server. This report is really necessary to check the detailed report.
+
+In addition to the HTML audit report, `playwright-lighthouse` can also produce CSV and JSON audit reports. These can be useful for ongoing audits and monitoring from build to build.
 
 ```js
 await playAudit({
   /* ... other configurations */
 
+  reports: {
+    json: true, //defaults to false
+    html: true, //defaults to false
+    csv: true //defaults to false
+  },
   htmlReport: true, //defaults to false
   reportDir: `path/to/directory`, //defaults to `${process.cwd()}/lighthouse`
   reportName: `name-of-the-report`, //defaults to `lighthouse-${new Date().getTime()}.html`
 });
 ```
 
-This will result in below HTML report
+Sample HTML report:
 
 ![screen](./docs/lighthouse_report.png)
 

--- a/src/audit.js
+++ b/src/audit.js
@@ -13,9 +13,13 @@ const defaultThresholds = {
 };
 
 const defaultReports = {
-  csv: false,
-  html: false,
-  json: false
+  formats: {
+    csv: false,
+    html: false,
+    json: false
+  },
+  name: `lighthouse-${new Date().getTime()}`,
+  directory:  `${process.cwd()}/lighthouse`
 };
 
 const VALID_BROWSERS = ['Chrome', 'Chromium', 'Canary'];
@@ -43,16 +47,17 @@ let playAudit = async function (auditConfig = {}) {
     );
   }
 
+  const reportsConfig = {
+    ...defaultReports,
+    ...auditConfig.reports,
+  };
+
   const { errors, results } = await lighthouse({
     url: auditConfig.page.url(),
     thresholds: auditConfig.thresholds || defaultThresholds,
     opts: auditConfig.opts,
     config: auditConfig.config,
-    reports: auditConfig.reports || defaultReports,
-    htmlReport: auditConfig.htmlReport || false,
-    reportDir: auditConfig.reportDir || `${process.cwd()}/lighthouse`,
-    reportName:
-      auditConfig.reportName || `lighthouse-${new Date().getTime()}`,
+    reports: reportsConfig,
     cdpPort: auditConfig.cdpPort,
   });
 

--- a/src/audit.js
+++ b/src/audit.js
@@ -12,6 +12,12 @@ const defaultThresholds = {
   pwa: 100,
 };
 
+const defaultReports = {
+  csv: false,
+  html: false,
+  json: false
+};
+
 const VALID_BROWSERS = ['Chrome', 'Chromium', 'Canary'];
 
 let playAudit = async function (auditConfig = {}) {
@@ -42,10 +48,11 @@ let playAudit = async function (auditConfig = {}) {
     thresholds: auditConfig.thresholds || defaultThresholds,
     opts: auditConfig.opts,
     config: auditConfig.config,
+    reports: auditConfig.reports || defaultReports,
     htmlReport: auditConfig.htmlReport || false,
     reportDir: auditConfig.reportDir || `${process.cwd()}/lighthouse`,
     reportName:
-      auditConfig.reportName || `lighthouse-${new Date().getTime()}.html`,
+      auditConfig.reportName || `lighthouse-${new Date().getTime()}`,
     cdpPort: auditConfig.cdpPort,
   });
 

--- a/src/task.js
+++ b/src/task.js
@@ -21,13 +21,33 @@ const compare = (thresholds, newValue) => {
   return { errors, results };
 };
 
+// if removed, would be a breaking change
 const getHtmlReport = async (lhr, dir, name) => {
+  name = name.substr(0, name.lastIndexOf('.')) || name;
   const html = ReportGenerator.generateReport(lhr, 'html');
   try {
     await fs.mkdirSync(dir, { recursive: true });
-    await fs.writeFileSync(`${dir}/${name}`, html);
+    await fs.writeFileSync(`${dir}/${name}.html`, html);
   } catch (err) {
     throw err;
+  }
+};
+
+const getReport = async (lhr, dir, name, type) => {
+  const validTypes = ['csv', 'html', 'json'];
+  name = name.substr(0, name.lastIndexOf('.')) || name;
+
+  if (validTypes.includes(type)) {
+    const reportBody = ReportGenerator.generateReport(lhr, type);
+    try {
+      await fs.mkdirSync(dir, {recursive: true });
+      await fs.writeFileSync(`${dir}/${name}.${type}`, reportBody);
+    } catch (err) {
+      throw err;
+    }
+  } else {
+    console.log(`Invalid report type specified: ${type} Skipping...)`)
+    // throw new Error(`Invalid report type specified: ${type})`);
   }
 };
 
@@ -36,6 +56,7 @@ exports.lighthouse = async ({
   thresholds,
   opts = {},
   config,
+  reports,
   htmlReport,
   reportDir,
   reportName,
@@ -60,6 +81,14 @@ exports.lighthouse = async ({
     {}
   );
 
+  for (var typeFromKey in reports){
+    var value = reports[typeFromKey];
+    if (value) {
+      await getReport(results.lhr, reportDir, reportName, typeFromKey);
+    }
+  }
+
+  // leaving in order to avoid a breaking change
   if (htmlReport) {
     await getHtmlReport(results.lhr, reportDir, reportName);
   }

--- a/src/task.js
+++ b/src/task.js
@@ -21,18 +21,6 @@ const compare = (thresholds, newValue) => {
   return { errors, results };
 };
 
-// if removed, would be a breaking change
-const getHtmlReport = async (lhr, dir, name) => {
-  name = name.substr(0, name.lastIndexOf('.')) || name;
-  const html = ReportGenerator.generateReport(lhr, 'html');
-  try {
-    await fs.mkdirSync(dir, { recursive: true });
-    await fs.writeFileSync(`${dir}/${name}.html`, html);
-  } catch (err) {
-    throw err;
-  }
-};
-
 const getReport = async (lhr, dir, name, type) => {
   const validTypes = ['csv', 'html', 'json'];
   name = name.substr(0, name.lastIndexOf('.')) || name;
@@ -46,8 +34,7 @@ const getReport = async (lhr, dir, name, type) => {
       throw err;
     }
   } else {
-    console.log(`Invalid report type specified: ${type} Skipping...)`)
-    // throw new Error(`Invalid report type specified: ${type})`);
+    console.log(`Invalid report type specified: ${type} Skipping Reports...)`)
   }
 };
 
@@ -57,9 +44,6 @@ exports.lighthouse = async ({
   opts = {},
   config,
   reports,
-  htmlReport,
-  reportDir,
-  reportName,
   cdpPort,
 }) => {
   opts.port = cdpPort;
@@ -81,16 +65,11 @@ exports.lighthouse = async ({
     {}
   );
 
-  for (var typeFromKey in reports){
-    var value = reports[typeFromKey];
+  for (var typeFromKey in reports['formats']){
+    var value = reports['formats'][typeFromKey];
     if (value) {
-      await getReport(results.lhr, reportDir, reportName, typeFromKey);
+      await getReport(results.lhr, reports['directory'], reports['name'], typeFromKey);
     }
-  }
-
-  // leaving in order to avoid a breaking change
-  if (htmlReport) {
-    await getHtmlReport(results.lhr, reportDir, reportName);
   }
 
   return compare(thresholds, newValues);

--- a/test/reports.spec.js
+++ b/test/reports.spec.js
@@ -1,8 +1,8 @@
 const { playAudit } = require('../index');
 const playwright = require('playwright');
 
-describe('audit example', () => {
-  it('audits page', async () => {
+describe('reports example', () => {
+  it('writes reports', async () => {
     const browser = await playwright['chromium'].launch({
       args: ['--remote-debugging-port=9222'],
     });
@@ -10,13 +10,14 @@ describe('audit example', () => {
     await page.goto('https://angular.io/');
 
     await playAudit({
+      reports: {
+        json: true,
+        html: true,
+        csv: true
+      },
       page: page,
       thresholds: {
-        performance: 50,
-        accessibility: 50,
-        'best-practices': 50,
-        seo: 50,
-        pwa: 50,
+        performance: 50
       },
       port: 9222,
     });

--- a/test/reports.spec.js
+++ b/test/reports.spec.js
@@ -1,8 +1,14 @@
+const fs = require('fs');
 const { playAudit } = require('../index');
 const playwright = require('playwright');
+const chai = require('chai')
+const expect = chai.expect
 
 describe('reports example', () => {
-  it('writes reports', async () => {
+  it('writes json and html reports', async () => {
+    const reportDirectory = `${process.cwd()}/lighthouse`;
+    const reportFilename = `lighthouse-${new Date().getTime()}`;
+
     const browser = await playwright['chromium'].launch({
       args: ['--remote-debugging-port=9222'],
     });
@@ -11,9 +17,13 @@ describe('reports example', () => {
 
     await playAudit({
       reports: {
-        json: true,
-        html: true,
-        csv: true
+        formats: {
+          json: true,
+          html: true,
+          csv: false
+        },
+        name: reportFilename,
+        directory:  reportDirectory
       },
       page: page,
       thresholds: {
@@ -21,6 +31,12 @@ describe('reports example', () => {
       },
       port: 9222,
     });
+
+    const jsonFile = reportDirectory +  "/" + reportFilename + ".json";
+    expect(fs.existsSync(jsonFile), `${jsonFile} does not exist.`).to.be.true;
+
+    const htmlFile = reportDirectory +  "/" + reportFilename + ".html";
+    expect(fs.existsSync(jsonFile), `${htmlFile} does not exist.`).to.equal(true);
 
     await browser.close();
   });


### PR DESCRIPTION
Adding support for CSV and JSON audit reports.

Tried to do this in a manner that would not break existing behavior; this means there is some level of redundant code.

Ideally, I would have removed existing HTML report functionality - but that would be a breaking change.
If ultimately we can go the breaking change route (new major version), the reporting code can be cleaned and tightened.

The new test is pretty lightweight and should be cleaned up. I'm thinking an additional tests PR would be in order; that would allow tightening of the existing test as well.