### PR TITLE
Fix passing in custom port

### DIFF
--- a/src/audit.js
+++ b/src/audit.js
@@ -58,7 +58,7 @@ let playAudit = async function (auditConfig = {}) {
     opts: auditConfig.opts,
     config: auditConfig.config,
     reports: reportsConfig,
-    cdpPort: auditConfig.cdpPort,
+    cdpPort: auditConfig.port,
   });
 
   log('\n');

--- a/test/audit.spec.js
+++ b/test/audit.spec.js
@@ -4,7 +4,7 @@ const playwright = require('playwright');
 describe('audit example', () => {
   before(async () => {
     browser = await playwright['chromium'].launch({
-      args: ['--remote-debugging-port=9222'],
+      args: ['--remote-debugging-port=9223'],
     });
     page = await browser.newPage();
     await page.goto('https://angular.io/');
@@ -24,7 +24,7 @@ describe('audit example', () => {
         seo: 50,
         pwa: 50,
       },
-      port: 9222,
+      port: 9223,
     });
   });
 });


### PR DESCRIPTION
Thanks for the library! I'm using it in my project but noticed a bug where it's not passing the custom port through to lighthouse. 

It's quite a severe bug as this prevents me from using the library with playwright-test, as playwright-test will run in parallel and I need to assign unique ports per lighthouse tests.

I've updated the tests to test this change.

I'd appreciate a new release as soon as possible. Many thanks.