### PR TITLE
Add comparison error to result when error is ignored

### DIFF
--- a/src/audit.js
+++ b/src/audit.js
@@ -76,14 +76,19 @@ let playAudit = async function (auditConfig = {}) {
     log(chalk.greenBright(res));
   });
 
-  if (auditConfig.ignoreError !== true && comparison.errors.length > 0) {
+  if (comparison.errors.length > 0) {
     const formateErrors = `\n\n${comparison.errors.join('\n')}`;
 
     const label =
       comparison.errors.length === 1
         ? `playwright lighthouse - A threshold is not matching the expectation.${formateErrors}`
         : `playwright lighthouse - Some thresholds are not matching the expectations.${formateErrors}`;
-    throw new Error(label);
+
+    if (auditConfig.ignoreError !== true) {
+      throw new Error(label);
+    } else {
+      results.comparisonError = label;
+    }
   }
 
   return results;

--- a/test/audit.spec.js
+++ b/test/audit.spec.js
@@ -1,5 +1,7 @@
 const { playAudit } = require('../index');
 const playwright = require('playwright-core');
+const chai = require('chai');
+const expect = chai.expect;
 
 describe('audit example', () => {
   let browser, page;
@@ -31,7 +33,7 @@ describe('audit example', () => {
   });
 
   it('no logs, no page, no errors', async () => {
-    await playAudit({
+    const result = await playAudit({
       url: 'https://angular.io/',
       thresholds: {
         performance: 100,
@@ -44,5 +46,6 @@ describe('audit example', () => {
       ignoreError: true,
       disableLogs: true,
     });
+    expect(typeof result.comparisonError).to.equal('string');
   });
 });


### PR DESCRIPTION
Introduce a way to distinguish if the comparison was successful or not to the `results` object.

Use case 
```
const result = await playAudit({ 
  ...,
  ignoreError: true
})

// do something with the results object

// finally, fail the test in case of any error
if (result.comparisonError) {
  throw new Error(comparisonError)
}
```

This is very helpful because I can use `result` object data in case of both failure and success and don't have to perform comparison by myself one more extra time.