### PR TITLE
[WIP] Use fraggle rock API for conducting lighthouse tests

### DIFF
--- a/src/audit.js
+++ b/src/audit.js
@@ -1,29 +1,10 @@
 const { lighthouse } = require('./task');
+const { patchPageObject, checkBrowserIsValid, defaultReports, defaultThresholds } = require('./util')
 
-const defaultThresholds = {
-  performance: 100,
-  accessibility: 100,
-  'best-practices': 100,
-  seo: 100,
-  pwa: 100,
-};
-
-const defaultReports = {
-  formats: {
-    csv: false,
-    html: false,
-    json: false,
-  },
-  name: `lighthouse-${new Date().getTime()}`,
-  directory: `${process.cwd()}/lighthouse`,
-};
-
-const VALID_BROWSERS = ['Chrome', 'Chromium', 'Canary'];
-
-let playAudit = async function (auditConfig = {}) {
-  if (!auditConfig.port || (!auditConfig.page && !auditConfig.url)) {
+const playAudit = async function (auditConfig = {}) {
+  if (!auditConfig.page && !auditConfig.url) {
     throw new Error(
-      `port, page or url is not set in playwright lighthouse config. Refer to https://github.com/abhinaba-ghosh/playwright-lighthouse to have more information and set it by yourself :). `
+      `page or url is not set in playwright lighthouse config. Refer to https://github.com/abhinaba-ghosh/playwright-lighthouse to have more information and set it by yourself :). `
     );
   }
 
@@ -59,13 +40,15 @@ let playAudit = async function (auditConfig = {}) {
     ...auditConfig.reports,
   };
 
+  patchPageObject(auditConfig.page);
+
   const { comparison, results } = await lighthouse({
     url,
+    page: auditConfig.page,
     thresholds: auditConfig.thresholds || defaultThresholds,
     opts: auditConfig.opts,
     config: auditConfig.config,
-    reports: reportsConfig,
-    cdpPort: auditConfig.port,
+    reports: reportsConfig
   });
 
   log('\n');
@@ -92,17 +75,6 @@ let playAudit = async function (auditConfig = {}) {
   }
 
   return results;
-};
-
-const checkBrowserIsValid = (browserName) => {
-  const matches = VALID_BROWSERS.filter((pattern) => {
-    return new RegExp(pattern).test(browserName);
-  });
-
-  if (matches.length > 0) {
-    return true;
-  }
-  return false;
 };
 
 exports.playAudit = playAudit;

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,87 @@
+const events = require('events');
+const ReportGenerator = require('lighthouse/report/generator/report-generator');
+const fs = require('fs/promises');
+
+const VALID_BROWSERS = ['Chrome', 'Chromium', 'Canary'];
+
+const defaultThresholds = {
+  performance: 100,
+  accessibility: 100,
+  'best-practices': 100,
+  seo: 100,
+  pwa: 100,
+};
+
+const defaultReports = {
+  formats: {
+    csv: false,
+    html: false,
+    json: false,
+  },
+  name: `lighthouse-${new Date().getTime()}`,
+  directory: `${process.cwd()}/lighthouse`,
+};
+
+const patchPageObject = (page) => {
+  page.target = function () {
+    return {
+      createCDPSession: async function () {
+        const session = await page.context().newCDPSession(page);
+        session.connection = () => new events.EventEmitter();
+        return session;
+      }
+    }
+  }
+}
+
+const checkBrowserIsValid = (browserName) => {
+  const matches = VALID_BROWSERS.filter((pattern) => {
+    return new RegExp(pattern).test(browserName);
+  });
+
+  if (matches.length > 0) {
+    return true;
+  }
+  return false;
+};
+
+const compare = (thresholds, newValue) => {
+  const errors = [];
+  const results = [];
+
+  Object.keys(thresholds).forEach((key) => {
+    if (thresholds[key] > newValue[key]) {
+      errors.push(
+        `${key} record is ${newValue[key]} and is under the ${thresholds[key]} threshold`
+      );
+    } else {
+      results.push(
+        `${key} record is ${newValue[key]} and desired threshold was ${thresholds[key]}`
+      );
+    }
+  });
+
+  return { errors, results };
+};
+
+const getReport = async (lhr, dir, name, type) => {
+  const validTypes = ['csv', 'html', 'json'];
+  name = name.substr(0, name.lastIndexOf('.')) || name;
+
+  if (validTypes.includes(type)) {
+    const reportBody = ReportGenerator.generateReport(lhr, type);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(`${dir}/${name}.${type}`, reportBody);
+  } else {
+    console.log(`Invalid report type specified: ${type} Skipping Reports...)`);
+  }
+};
+
+module.exports = {
+  defaultReports,
+  defaultThresholds,
+  patchPageObject,
+  checkBrowserIsValid,
+  compare,
+  getReport
+}


### PR DESCRIPTION
In the legacy lighthouse flow, a browser needs to be started with remote debugging port enabled and lighthouse starts testing by firing CDP commands over this RDP. Lighthouse team has been working on the fraggle rock API with flow support and several API changes (see: https://github.com/GoogleChrome/lighthouse/issues/11313). This also includes a navigation API that can connect to existing puppeteer page instance for performing lighthouse tests. 
By modifying the playwright object slightly, we can utilise the fraggle rock API for performing lighthouse tests.

Benefits
- Using existing page object allows for connection with remote browsers. Helpful for running tests on remote browsers of cloud providers such as Browserstack.
- Since tests will be run in the same page context passed to `playwright-lighthouse`, authenticated workflows will not break.