### PR TITLE
Add IgnoreBrowserName option to avoid BrowserName check

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ export interface playwrightLighthouseConfig {
   };
   ignoreError?: boolean;
   disableLogs?: boolean;
+  ignoreBrowserName?: boolean;
 }
 
 /**

--- a/src/audit.js
+++ b/src/audit.js
@@ -33,7 +33,7 @@ export const playAudit = async function (auditConfig = {}) {
     : await import('chalk').then((m) => m.default);
 
   const url = auditConfig.url || auditConfig.page.url();
-  if (auditConfig.page) {
+  if (auditConfig.page && !auditConfig.ignoreBrowserName) {
     const { default: uaParser } = await import('ua-parser-js');
 
     // eslint-disable-next-line no-undef

--- a/test/audit.spec.js
+++ b/test/audit.spec.js
@@ -48,4 +48,19 @@ describe('audit example', () => {
     });
     expect(typeof result.comparisonError).to.equal('string');
   });
+
+  it('ignore browserName', async () => {
+    await playAudit({
+      page: page,
+      ignoreBrowserName: true,
+      thresholds: {
+        performance: 30,
+        accessibility: 50,
+        'best-practices': 50,
+        seo: 50,
+        pwa: 50,
+      },
+      port: 9223,
+    });
+  });
 });


### PR DESCRIPTION
Idea coming from: https://github.com/abhinaba-ghosh/playwright-lighthouse/issues/30

To be able to use modified user-agents that are browser-agnostic for professional reasons we need to add a boolean to avoid the BrowserName check when the lighthouse test starts.