### PR TITLE
Allow running lighthouse tests on Edge and Opera

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ import { playAudit } from "playwright-lighthouse";
   let browser, page;
   try {
     const capabilities = {
-      browserName: "Chrome",
+      browserName: "Chrome", // Browsers allowed: `Chrome`, `MicrosoftEdge` and `pw-chromium`
       browserVersion: "latest",
       "LT:Options": {
         platform: "Windows 11",

--- a/src/audit.js
+++ b/src/audit.js
@@ -18,7 +18,7 @@ const defaultReports = {
   directory: `${process.cwd()}/lighthouse`,
 };
 
-const VALID_BROWSERS = ['Chrome', 'Chromium', 'Canary'];
+const VALID_BROWSERS = ['Chrome', 'Chromium', 'Canary', 'Edge', 'Opera'];
 
 export const playAudit = async function (auditConfig = {}) {
   if (process.env.LIGHTHOUSE_LAMBDATEST === 'true') {


### PR DESCRIPTION
- Allow running lighthouse tests on Edge and Opera as those are Chromium based browsers and supports lighthouse
- Users run Playwrigth tests on Edge and Opera on LambdaTest and also in their local environment by adding a custom browser path(https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server-option-executable-path).
- Thus, we need to allow `Edge` and `Opera` to generate lighthouse reports.