### PR TITLE
Add comparisonError to playwrightLighthouseResult

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ export interface playwrightLighthouseConfig {
 
 export interface playwrightLighthouseResult extends RunnerResult {
   comparison?: string;
+  comparisonError?: string;
 }
 
 /**


### PR DESCRIPTION
Add `comparisonError` to `playwrightLighthouseResult`. Fixes #67